### PR TITLE
feat: stomp 방식으로 메세지 발행/구독 구현

### DIFF
--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/configs/StompConfiguration.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/configs/StompConfiguration.java
@@ -1,0 +1,27 @@
+package com.addict.jjangsky.chatservice.configs;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@EnableWebSocketMessageBroker
+@Configuration
+public class StompConfiguration implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // 서버가 어떠한 경로로 접근하는지 엔드포인트 지정
+        registry.addEndpoint("/stomp/chats");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 메세지 브로커의 역할을 하기위해 클라이언트에서 메세지 발행,
+        // 클라이언트는 브로커로부터 전달되는 메시지를 받기 위해
+        // 구독을 신청해야 하는데 해당 경로를 설정해 주는 곳
+
+        registry.setApplicationDestinationPrefixes("/pub"); // 메세지 발행
+        registry.enableSimpleBroker("/sub"); // 메세지 구독
+    }
+}

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/controllers/StompChatController.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/controllers/StompChatController.java
@@ -1,0 +1,19 @@
+package com.addict.jjangsky.chatservice.controllers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@Slf4j
+public class StompChatController {
+
+    @MessageMapping("/chats") //  /pub/chats -> 발행으로 하면 `/chats` 으로 전달됨
+    @SendTo("/sub/chats") // 구독자에게 메세지 전달
+    public String handleMessage(@Payload String message){
+        log.info("{}", message);
+        return message;
+    }
+}

--- a/chat-service/src/main/resources/static/index.html
+++ b/chat-service/src/main/resources/static/index.html
@@ -7,7 +7,7 @@
   <link href="/main.css" rel="stylesheet">
   <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7.0.0/bundles/stomp.umd.min.js"></script>
-  <script src="/websocket.js"></script>
+  <script src="/stomp.js"></script>
 </head>
 <body>
 <noscript><h2 style="color: #ff0000">Seems your browser doesn't support Javascript! Websocket relies on Javascript being


### PR DESCRIPTION
> * #3

 `WebSocketMessageBrokerConfigurer` 를 사용하여 발행/구독 형식의 채팅 서비스 구현

```
@Override
    public void registerStompEndpoints(StompEndpointRegistry registry) {
        // 서버가 어떠한 경로로 접근하는지 엔드포인트 지정
        registry.addEndpoint("/stomp/chats");
    }

    @Override
    public void configureMessageBroker(MessageBrokerRegistry registry) {
        // 메세지 브로커의 역할을 하기위해 클라이언트에서 메세지 발행,
        // 클라이언트는 브로커로부터 전달되는 메시지를 받기 위해
        // 구독을 신청해야 하는데 해당 경로를 설정해 주는 곳

        registry.setApplicationDestinationPrefixes("/pub"); // 메세지 발행
        registry.enableSimpleBroker("/sub"); // 메세지 구독
    }
```
`/stomp/chats` 엔드포인트로 요청 하여 연결 후, `/pub/~` 으로 메세지를 발행하면 `/sub/~` 으로 메세지브로커를 구독하고 있는 클라이언트들에게 메세지 전송되는 구조
