### PR TITLE
feat: oauth2를 활용한 카카오톡 로그인 처리

### DIFF
--- a/chat-service/.gitignore
+++ b/chat-service/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### application.yml ###
+*.yml

--- a/chat-service/.gitignore
+++ b/chat-service/.gitignore
@@ -37,4 +37,4 @@ out/
 .vscode/
 
 ### application.yml ###
-*.yml
+/src/main/resources/application.yml

--- a/chat-service/build.gradle
+++ b/chat-service/build.gradle
@@ -26,9 +26,11 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/chat-service/build.gradle
+++ b/chat-service/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-ouath2-client'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/chat-service/build.gradle
+++ b/chat-service/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-ouath2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/chat-service/src/main/resources/application-dev.yml
+++ b/chat-service/src/main/resources/application-dev.yml
@@ -1,0 +1,27 @@
+spring:
+  application:
+    name: chat-service
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: {client-id}
+            client-secret: {client-secret}
+            scope:
+              - profile_nickname
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            client-name: kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+
+
+


### PR DESCRIPTION
* #5 

> 카카오톡 로그인 (https://developers.kakao.com/)

![image](https://github.com/user-attachments/assets/88b6a29a-6bef-46dc-95c8-cb43309d5997)


```
  security:
    oauth2:
      client:
        registration:
          kakao:
            client-id: {client-id}
            client-secret: {client-secret}
            scope:
              - profile_nickname
            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
            client-name: kakao
            authorization-grant-type: authorization_code
            client-authentication-method: client_secret_post

        provider:
          kakao:
            authorization-uri: https://kauth.kakao.com/oauth/authorize
            token-uri: https://kauth.kakao.com/oauth/token
            user-info-uri: https://kapi.kakao.com/v2/user/me
            user-name-attribute: id


```

![image](https://github.com/user-attachments/assets/0816f3fc-bb04-4f72-b4a9-8e3d06ba876a)

oauth2를 사용하여 로그인을 구현하려면 스프링 시큐리티에서 `UsernamePasswordauthenticationFilter` 가 아닌 `Oauth2LoginAuthenticationFilter` 를 사용하여 검증 처리 구현해야 함



