### PR TITLE
feat: 카카오톡 사용자 정보를 사용하여 회원가입 처리

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/chat-service" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/chat-service" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/websocket.iml" filepath="$PROJECT_DIR$/.idea/websocket.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/websocket.iml
+++ b/.idea/websocket.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/chat-service/.gitignore
+++ b/chat-service/.gitignore
@@ -37,4 +37,4 @@ out/
 .vscode/
 
 ### application.yml ###
-/src/main/resources/application.yml
+application.yml

--- a/chat-service/build.gradle
+++ b/chat-service/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/controllers/StompChatController.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/controllers/StompChatController.java
@@ -1,10 +1,15 @@
 package com.addict.jjangsky.chatservice.controllers;
 
+import com.addict.jjangsky.chatservice.dtos.ChatMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+import java.util.Map;
 
 @Controller
 @Slf4j
@@ -12,8 +17,9 @@ public class StompChatController {
 
     @MessageMapping("/chats") //  /pub/chats -> 발행으로 하면 `/chats` 으로 전달됨
     @SendTo("/sub/chats") // 구독자에게 메세지 전달
-    public String handleMessage(@Payload String message){
-        log.info("{}", message);
-        return message;
+    public ChatMessage handleMessage(@AuthenticationPrincipal Principal principal,
+                                     @Payload Map<String, String> payload) {
+
+        return new ChatMessage(principal.getName(), payload.get("message"));
     }
 }

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/dtos/ChatMessage.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/dtos/ChatMessage.java
@@ -1,0 +1,7 @@
+package com.addict.jjangsky.chatservice.dtos;
+
+public record ChatMessage (
+        String sender,
+        String message
+){
+}

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/entities/Member.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/entities/Member.java
@@ -1,11 +1,18 @@
 package com.addict.jjangsky.chatservice.entities;
 
-import com.nimbusds.openid.connect.sdk.claims.Gender;
+import com.addict.jjangsky.chatservice.enums.Gender;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 
 import java.time.LocalDate;
 
+@Builder
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 public class Member {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,4 +28,5 @@ public class Member {
     String phoneNumber;
     LocalDate birthDay;
     String role;
+
 }

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/entities/Member.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/entities/Member.java
@@ -4,12 +4,14 @@ import com.addict.jjangsky.chatservice.enums.Gender;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 
 import java.time.LocalDate;
 
 @Builder
+@Getter
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/entities/Member.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/entities/Member.java
@@ -1,0 +1,24 @@
+package com.addict.jjangsky.chatservice.entities;
+
+import com.nimbusds.openid.connect.sdk.claims.Gender;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+@Entity
+public class Member {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    @Id
+    Long id;
+
+    String email;
+    String nickName;
+    String name;
+    @Enumerated(EnumType.STRING)
+    Gender gender;
+    String phoneNumber;
+    LocalDate birthDay;
+    String role;
+}

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/enums/Gender.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/enums/Gender.java
@@ -1,0 +1,5 @@
+package com.addict.jjangsky.chatservice.enums;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/repositories/MemberRepository.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/repositories/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.addict.jjangsky.chatservice.repositories;
+
+import com.addict.jjangsky.chatservice.entities.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+}

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/service/CustomOAuth2UserService.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/service/CustomOAuth2UserService.java
@@ -1,0 +1,57 @@
+package com.addict.jjangsky.chatservice.service;
+
+import com.addict.jjangsky.chatservice.entities.Member;
+import com.addict.jjangsky.chatservice.enums.Gender;
+import com.addict.jjangsky.chatservice.repositories.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    // DefaultOAuth2UserService를 확장해서 필요한 부분만 사용
+
+    private final MemberRepository memberRepository;
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        Map<String, Object> attributeMap = oAuth2User.getAttribute("kakao_account");
+        String email = (String) attributeMap.get("email");
+        Member member = memberRepository.findByEmail(email)
+                // 값이 없을 경우 회원 정보를 생성
+                .orElseGet(() ->  registerMember(attributeMap));
+
+        return oAuth2User;
+    }
+
+    private Member registerMember(Map<String, Object> attributeMap) {
+        Member member = Member.builder()
+                .email((String) attributeMap.get("email"))
+                .nickName((String) ((Map)attributeMap.get("profile")).get("nickname"))
+                .name((String) attributeMap.get("name"))
+                .phoneNumber((String) attributeMap.get("phone_number"))
+                .gender(Gender.valueOf(((String) attributeMap.get("gender")).toUpperCase()))
+                .birthDay(getBirthDay(attributeMap))
+                .role("ROLE_USER")
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private LocalDate getBirthDay(Map<String, Object> attributeMap) {
+        String birthYear = (String) attributeMap.get("birthyear");
+        String birthDay = (String) attributeMap.get("birthday");
+
+        return LocalDate.parse(birthYear + birthDay, DateTimeFormatter.BASIC_ISO_DATE);
+    }
+
+}

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/service/CustomOAuth2UserService.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/service/CustomOAuth2UserService.java
@@ -3,6 +3,7 @@ package com.addict.jjangsky.chatservice.service;
 import com.addict.jjangsky.chatservice.entities.Member;
 import com.addict.jjangsky.chatservice.enums.Gender;
 import com.addict.jjangsky.chatservice.repositories.MemberRepository;
+import com.addict.jjangsky.chatservice.vos.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -31,7 +32,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 // 값이 없을 경우 회원 정보를 생성
                 .orElseGet(() ->  registerMember(attributeMap));
 
-        return oAuth2User;
+        return new CustomOAuth2User(member, oAuth2User.getAttributes());
     }
 
     private Member registerMember(Map<String, Object> attributeMap) {

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/vos/CustomOAuth2User.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/vos/CustomOAuth2User.java
@@ -1,0 +1,36 @@
+package com.addict.jjangsky.chatservice.vos;
+
+import com.addict.jjangsky.chatservice.entities.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@AllArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+    // 인증 객체 구현체 -> OAuth2User를 구현
+    // 그대로 사용하는 것이 아닌 우리가 만든 `Member` 객체를 사용하기 위해 수정
+
+    @Getter
+    Member member;
+    Map<String, Object> attributeMap;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return this.attributeMap;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> member.getRole());
+    }
+
+    @Override
+    public String getName() {
+        return this.member.getNickName();
+    }
+}

--- a/chat-service/src/main/resources/application-dev.yml
+++ b/chat-service/src/main/resources/application-dev.yml
@@ -16,6 +16,12 @@ spring:
             client-secret: ${client-secret}
             scope:
               - profile_nickname
+              - account_email
+              - name
+              - gender
+              - birthday
+              - birthyear
+              - phone_number
             redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
             client-name: kakao
             authorization-grant-type: authorization_code

--- a/chat-service/src/main/resources/application-dev.yml
+++ b/chat-service/src/main/resources/application-dev.yml
@@ -1,13 +1,19 @@
 spring:
   application:
     name: chat-service
+  datasource:
+    url: jdbc:mysql://mysql:3306/${ MYSQL_DATABASE }
+    username: ${ MYSQL_USER }
+    password: ${ MYSQL_PASSWORD }
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
   security:
     oauth2:
       client:
         registration:
           kakao:
-            client-id: {client-id}
-            client-secret: {client-secret}
+            client-id: ${client-id}
+            client-secret: ${client-secret}
             scope:
               - profile_nickname
             redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"

--- a/chat-service/src/main/resources/application.yml
+++ b/chat-service/src/main/resources/application.yml
@@ -1,3 +1,0 @@
-spring:
-  application:
-    name: chat-service

--- a/chat-service/src/main/resources/static/index.html
+++ b/chat-service/src/main/resources/static/index.html
@@ -18,10 +18,6 @@
     <div class="col-md-6">
       <form class="form-inline">
         <div class="form-group">
-          <label for="username">Username</label>
-          <input type="text" id="username" class="form-control" placeholder="username to send">
-        </div>
-        <div class="form-group">
           <label for="connect">WebSocket connection:</label>
           <button id="connect" class="btn btn-default" type="button">Connect</button>
           <button id="disconnect" class="btn btn-default" disabled="disabled" type="button">Disconnect

--- a/chat-service/src/main/resources/static/stomp.js
+++ b/chat-service/src/main/resources/static/stomp.js
@@ -11,7 +11,7 @@ stompClient.onConnect = (frame) => {
   stompClient.publish({
     destination: "/pub/chats",
     body: JSON.stringify(
-        {'sender': $("#username").val(), 'message': "connected"})
+        {'message': "connected"})
   })
 };
 
@@ -49,7 +49,7 @@ function sendMessage() {
   stompClient.publish({
     destination: "/pub/chats",
     body: JSON.stringify(
-        {'sender': $("#username").val(), 'message': $("#message").val()})
+        {'message': $("#message").val()})
   });
   $("#message").val("")
 }


### PR DESCRIPTION
* #7 

![image](https://github.com/user-attachments/assets/dc91ff1b-07d4-4f7f-ac26-96e3cad84b2b)

`DefaultOAuth2UserService` 를 상속 받은 서비스 로직을 사용하여 인증 로직 가공
- 인증 과정에서 서버 DB에 사용자 정보 저장 처리 
- `OAuth2User` 구현체를 사용하여 반환 되는 사용자 인증 정보 객체 가공 