### PR TITLE
feat: 이전 메세지 내역 불러오기

### DIFF
--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/controllers/ChatController.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/controllers/ChatController.java
@@ -1,7 +1,9 @@
 package com.addict.jjangsky.chatservice.controllers;
 
+import com.addict.jjangsky.chatservice.dtos.ChatMessage;
 import com.addict.jjangsky.chatservice.dtos.ChatroomDto;
 import com.addict.jjangsky.chatservice.entities.Chatroom;
+import com.addict.jjangsky.chatservice.entities.Message;
 import com.addict.jjangsky.chatservice.service.ChatService;
 import com.addict.jjangsky.chatservice.vos.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
@@ -47,4 +49,15 @@ public class ChatController {
                 .map(ChatroomDto::from)
                 .toList();
     }
+
+    @GetMapping("/{chatroomId}/messages")
+    public List<ChatMessage> getMessageList(@PathVariable Long chatroomId) {
+
+        List<Message> messageList = chatService.getMessageList(chatroomId);
+
+        return messageList.stream()
+                .map(message -> new ChatMessage(message.getMember().getNickName(), message.getText()))
+                .toList();
+    }
+
 }

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/controllers/StompChatController.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/controllers/StompChatController.java
@@ -1,26 +1,37 @@
 package com.addict.jjangsky.chatservice.controllers;
 
 import com.addict.jjangsky.chatservice.dtos.ChatMessage;
+import com.addict.jjangsky.chatservice.entities.Message;
+import com.addict.jjangsky.chatservice.service.ChatService;
+import com.addict.jjangsky.chatservice.vos.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
 import java.util.Map;
 
 @Controller
+@RequiredArgsConstructor
 @Slf4j
 public class StompChatController {
+
+    private final ChatService chatService;
 
     @MessageMapping("/chats/{chatroomId}") //  /pub/chats -> 발행으로 하면 `/chats` 으로 전달됨
     @SendTo("/sub/chats/{chatroomId}") // 구독자에게 메세지 전달
     public ChatMessage handleMessage(@AuthenticationPrincipal Principal principal,
                                      @DestinationVariable Long chatroomId,
                                      @Payload Map<String, String> payload) {
+
+        CustomOAuth2User user = (CustomOAuth2User) ((OAuth2AuthenticationToken) principal).getPrincipal();
+        Message message = chatService.saveMessage(user.getMember(), chatroomId, payload.get("message"));
 
         return new ChatMessage(principal.getName(), payload.get("message"));
     }

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/entities/Message.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/entities/Message.java
@@ -1,0 +1,21 @@
+package com.addict.jjangsky.chatservice.entities;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Message {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id")
+    @Id
+    Long id;
+
+    String text;
+    @JoinColumn(name="member_id")
+    @ManyToOne
+    Member member;
+
+    @JoinColumn(name="chatroom_id")
+    @ManyToOne
+    Chatroom chatroom;
+}

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/entities/Message.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/entities/Message.java
@@ -1,8 +1,16 @@
 package com.addict.jjangsky.chatservice.entities;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class Message {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/repositories/MessageRepository.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/repositories/MessageRepository.java
@@ -1,0 +1,10 @@
+package com.addict.jjangsky.chatservice.repositories;
+
+import com.addict.jjangsky.chatservice.entities.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+    List<Message> findAllByChatroomId(Long chatroomId);
+}

--- a/chat-service/src/main/java/com/addict/jjangsky/chatservice/service/ChatService.java
+++ b/chat-service/src/main/java/com/addict/jjangsky/chatservice/service/ChatService.java
@@ -3,8 +3,10 @@ package com.addict.jjangsky.chatservice.service;
 import com.addict.jjangsky.chatservice.entities.Chatroom;
 import com.addict.jjangsky.chatservice.entities.Member;
 import com.addict.jjangsky.chatservice.entities.MemberChatroomMapping;
+import com.addict.jjangsky.chatservice.entities.Message;
 import com.addict.jjangsky.chatservice.repositories.ChatroomRepository;
 import com.addict.jjangsky.chatservice.repositories.MemberChatroomMappingRepository;
+import com.addict.jjangsky.chatservice.repositories.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,7 @@ public class ChatService {
 
     private final ChatroomRepository chatroomRepository;
     private final MemberChatroomMappingRepository memberChatroomMappingRepository;
+    private final MessageRepository messageRepository;
 
 
     /**
@@ -91,6 +94,22 @@ public class ChatService {
         return memberChatroomMappingList.stream()
                 .map(MemberChatroomMapping::getChatroom)
                 .toList();
+    }
+
+    public Message saveMessage(Member member, Long chatroomId, String text){
+        Chatroom chatroom = chatroomRepository.findById(chatroomId).get();
+
+        Message message = Message.builder()
+                .text(text)
+                .member(member)
+                .chatroom(chatroom)
+                .build();
+
+        return messageRepository.save(message);
+    }
+
+    public List<Message> getMessageList(Long chatroomId){
+        return messageRepository.findAllByChatroomId(chatroomId);
     }
 
 }

--- a/chat-service/src/main/resources/static/stomp.js
+++ b/chat-service/src/main/resources/static/stomp.js
@@ -34,20 +34,17 @@ function disconnect() {
 }
 
 function sendMessage() {
+  console.log("실행")
   let chatroomId = $("#chatroom-id").val()
+  console.log(chatroomId);
   stompClient.publish({
-    destination: "/pub/chats" + chatroomId,
+    destination: "/pub/chats/" + chatroomId,
     body: JSON.stringify(
         {'message': $("#message").val()})
   });
   $("#message").val("")
 }
 
-function showMessage(chatMessage) {
-  $("#messages").append(
-      "<tr><td>" + chatMessage.sender + " : " + chatMessage.message
-      + "</td></tr>");
-}
 function createChatroom() {
   $.ajax({
     type: 'POST',
@@ -98,6 +95,7 @@ let subscription;
 function enterChatroom(chatroomId, newMember){
   $("#chatroom-id").val(chatroomId);
   $("#message").html("");
+  showMessages(chatroomId);
   $("#conversation").show();
   $("#send").prop("disabled", false);
   $("#leave").prop("disabled", false);
@@ -116,6 +114,32 @@ function enterChatroom(chatroomId, newMember){
           {'message': "님이 방에 입장하셨습니다."})
     })
   }
+}
+
+function showMessages(chatroomId){
+  $.ajax({
+    type: 'GET',
+    dataType: 'json',
+    url: '/chats/' + chatroomId + '/messages',
+    success: function (data){
+      console.log('data', data);
+      for(let i = 0; data.length; i++){
+        showMessage(data[i]);
+      }
+
+
+    },
+    error: function(request, status, error){
+      console.log('request', request);
+      console.log('error', error)
+    }
+  })
+}
+
+function showMessage(chatMessage) {
+  $("#messages").append(
+      "<tr><td>" + chatMessage.sender + " : " + chatMessage.message
+      + "</td></tr>");
 }
 
 function joinChatroom(chatroomId){


### PR DESCRIPTION
* #11 

이전 버전에서는 온라인 상태에서만 메세지를 확인할 수 있으며 채팅 종료 시 내역을 확인할 수 없음

과거의 메세지를 불러오기 위해 메세지 전달 과정에서 DB에 메세지 저장 후, 채팅방 입장 시 저장된 메세지 내역 조회 처리

```mermaid
erDiagram
    Message {
        Long message_id PK
        String text
        Long member_id FK
        Long chatroom_id FK
    }
    Member {
        Long member_id PK
    }
    Chatroom {
        Long chatroom_id PK
    }
    
    Message }|--|| Member : "belongs to"
    Message }|--|| Chatroom : "belongs to"
```